### PR TITLE
fix(tests): auto-heal broken locator: profile update persists in ui

### DIFF
--- a/tests/pom/profile-page.ts
+++ b/tests/pom/profile-page.ts
@@ -9,7 +9,7 @@ export class ProfilePage extends BasePage {
   constructor(page: Page) {
     super(page)
     this.currentDisplayName = this.byTestId('profile-displayname')
-    this.editDisplayNameInput = this.byTestId('displayname-edit-input')
+    this.editDisplayNameInput = this.getByTestId('displayname-edit-input') // Updated here
     this.saveButton = this.byTestId('save-profile-button')
   }
 
@@ -22,4 +22,3 @@ export class ProfilePage extends BasePage {
     await this.saveButton.click()
   }
 }
-


### PR DESCRIPTION
## Auto-Generated Heal PR

**Failure:** Test timeout of 30000ms exceeded.
**Reason:** Timeout exceeded due to stale selector or renamed data-testid
**Confidence:** 0.93
**CI Run:** 
**Target file updated:** tests/pom/profile-page.ts
**Original locator:** this.byTestId('displayname-edit-input')
**Proposed locator:** this.getByTestId('displayname-edit-input')
**Linked issue:** #25

Closes #25

> Review before merging — verify locator updates are correct.