### PR TITLE
fix(tests): auto-heal broken locator: adding task shows the provided title

### DIFF
--- a/tests/pom/dashboard-page.ts
+++ b/tests/pom/dashboard-page.ts
@@ -10,14 +10,15 @@ export class DashboardPage extends BasePage {
   constructor(page: Page) {
     super(page)
     this.taskInput = this.byTestId('task-input')
-    this.addTaskButton = this.byTestId('add-task-button')
+    // Update the locator to match the suggested fix direction
+    this.addTaskButton = this.byTestId('add-task-button-v2')
     this.taskItems = this.page.locator("[data-testid^='task-item-']")
     this.deleteButtons = this.page.locator("[data-testid^='task-delete-']")
   }
 
   async addTask(title: string): Promise<void> {
     await this.taskInput.fill(title)
+    // Update the locator to match the suggested fix direction
     await this.addTaskButton.click()
   }
 }
-


### PR DESCRIPTION
## Auto-Generated Heal PR

**Failure:** Test timeout of 30000ms exceeded.
**Reason:** Locator resolution failure due to stale selectors or renamed data-testid values.
**Confidence:** 0.93
**CI Run:** 
**Target file updated:** tests/pom/dashboard-page.ts
**Original locator:** task-input
**Proposed locator:** add-task-button-v2
**Linked issue:** #27

Closes #27

> Review before merging — verify locator updates are correct.