### PR TITLE
fix(tests): dashboard-page add-task-button->add-task-button-v2

### DIFF
--- a/tests/pom/dashboard-page.ts
+++ b/tests/pom/dashboard-page.ts
@@ -10,7 +10,7 @@ export class DashboardPage extends BasePage {
   constructor(page: Page) {
     super(page)
     this.taskInput = this.byTestId('task-input')
-    this.addTaskButton = this.byTestId('add-task-button')
+    this.addTaskButton = this.byTestId('add-task-button-v2')
     this.taskItems = this.page.locator("[data-testid^='task-item-']")
     this.deleteButtons = this.page.locator("[data-testid^='task-delete-']")
   }
@@ -20,4 +20,3 @@ export class DashboardPage extends BasePage {
     await this.addTaskButton.click()
   }
 }
-


### PR DESCRIPTION
## Auto-Generated Heal PR

**Failure:** Test timeout of 30000ms exceeded.
**Reason:** Locator resolution failure due to stale selectors or renamed data-testid values.
**Confidence:** 0.93
**CI Run:** 
**Target file updated:** tests/pom/dashboard-page.ts
**Original locator:** add-task-button
**Proposed locator:** add-task-button-v2
**Linked issue:** #40

Closes #40

> Review before merging — verify locator updates are correct.